### PR TITLE
Fixes useless app related errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,12 +7,14 @@ module.exports = {
     "plugin:node/recommended"
   ],
   "rules": {
+    "node/no-missing-require": ["error", {"allowModules": ["homey"]}],
     "node/exports-style": ["error", "module.exports"],
     "no-underscore-dangle": "off",
     "max-len": ["warn", {
       "code": 300
     }],
     "consistent-return": "off",
+    "no-bitwise": "off",
     "no-param-reassign": ["warn"],
     "no-await-in-loop": "off",
     "no-empty": "off",
@@ -27,6 +29,10 @@ module.exports = {
     "no-continue": "off"
   },
   "parserOptions": {
-    "sourceType": "script"
+    "sourceType": "script",
+    "ecmaVersion": 2018
+  },
+  "settings": {
+    "import/core-modules": ["homey"]
   }
 }


### PR DESCRIPTION
Fixes errors related to: 

`homey` module not being found by `require`, these were thrown twice per Homey include as `import/no-unresolved` and `node/no-missing-require` both indicating that the module wasn't found in `node_modules`. 

Bitwise operations reporting as errors which cause a lot of errors for 433/Z-Wave/Zigbee applications where bitmasks and bit operations are often necessary.

Enforces ecmaScript 2018 unless defined otherwise in .eslintrc.json, as otherwise eslint won't run with parsing error: invalid ecmaVersion.