### PR TITLE
Allow for..of loops

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,28 @@ module.exports = {
     "curly": "off",
     "prefer-destructuring": "off",
     "class-methods-use-this": "off",
-    "no-continue": "off"
+    "no-continue": "off",
+    // copied from https://github.com/airbnb/javascript/blob/6d05dd898acfec3299cc2be8b6188be542824965/packages/eslint-config-airbnb-base/rules/style.js#L332-L352
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "ForInStatement",
+        "message": "for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array."
+      },
+      // we don't transpile so allow for..of loops
+      // {
+      //   "selector": "ForOfStatement",
+      //   "message": "iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations."
+      // },
+      {
+        "selector": "LabeledStatement",
+        "message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand."
+      },
+      {
+        "selector": "WithStatement",
+        "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize."
+      }
+    ]
   },
   "parserOptions": {
     "sourceType": "script",


### PR DESCRIPTION
`"iterators/generators require regenerator-runtime ..."` is nonsense when using a modern version of node.
Keep disallowing labels, `with` and `for..in`