### PR TITLE
brace-style disable allowSingleLine

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 module.exports = {
   "parser": "babel-eslint",
@@ -11,9 +11,11 @@ module.exports = {
   "rules": {
     "strict": ["error", "global"],
 
-    "lines-between-class-members": ["error", "always", {
-      "exceptAfterSingleLine": true
-    }],
+    "lines-between-class-members": [
+      "error",
+      "always",
+      { "exceptAfterSingleLine": true }
+    ],
 
     "node/no-missing-require": ["error", { "allowModules": ["homey"] }],
 
@@ -35,7 +37,7 @@ module.exports = {
 
     "dot-notation": "off",
 
-    'space-before-function-paren': [
+    "space-before-function-paren": [
       "error",
       { "anonymous": "never", "named": "never", "asyncArrow": "always" }
     ],

--- a/index.js
+++ b/index.js
@@ -58,6 +58,8 @@ module.exports = {
       { "overrides": { "if": "any" } }
     ],
 
+    "brace-style": ["error", "1tbs"],
+
     "no-restricted-syntax": [
       "error",
       {


### PR DESCRIPTION
changes the [`brace-style`](https://eslint.org/docs/rules/brace-style) rule to disallow 
```js
if (blah) { return false; }
```

see https://github.com/airbnb/javascript/blob/6d05dd898acfec3299cc2be8b6188be542824965/packages/eslint-config-airbnb-base/rules/style.js#L21

instead use either:

```js
if (blah) return false;
```

or 

```js
if (blah) {
  return false;
}
```
