### PR TITLE
Set sourceType to "script" (default)

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ module.exports = {
     "airbnb-base",
     "plugin:node/recommended"
   ],
+  
+  "parserOptions": {
+    "sourceType": "script"
+  },
 
   "rules": {
     "strict": ["error", "global"],


### PR DESCRIPTION
This prevents `eslint -- fix` from removing 'use strict'.