### PR TITLE
disable arrow-body-style rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ module.exports = {
       { "exceptAfterSingleLine": true }
     ],
 
+    "arrow-body-style": "off",
+
     "node/no-missing-require": ["error", { "allowModules": ["homey"] }],
 
     "no-underscore-dangle": "off",


### PR DESCRIPTION
Disables the [`arrow-body-style`](https://eslint.org/docs/rules/arrow-body-style) rule.

see: https://github.com/airbnb/javascript/blob/8148bfce3c670a8a234ee71903ca020e32506884/packages/eslint-config-airbnb-base/rules/es6.js#L18

There are a lot of cases where i strongly prefer having a return instead of the "implicit" arrow return, for example:

```js
// what I find more readable
() => {
  return {
    some: 'data',
    some: 'data',
    some: 'data',
  };
} 
```

vs 

```js
// what the eslint rule currently wants me to do
() => ({
  some: 'data',
  some: 'data',
  some: 'data',
});
```

This also affects arrow functions that have a really long single line body, see Emiles video in slack#development