### PR TITLE
feat: use arrow-parens always

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,8 +47,6 @@ module.exports = {
 
     "no-plusplus": "off",
 
-    "arrow-parens": ["error", "as-needed"],
-
     "class-methods-use-this": "off",
 
     "no-continue": "off",


### PR DESCRIPTION
Before
```js
const log = msg => console.log(msg);
```
After
```js
const log = (msg) => console.log(msg);
```

Rule: https://eslint.org/docs/rules/arrow-parens
Note that this is the default for this rule (and it is included in ESLints "recommended" configuration)

Airbnb has a great explanation for what potential errors "always" prevents: https://github.com/airbnb/javascript#arrows--one-arg-parens

I got thinking about this due to prettier's recent 2.0.0 release that changes their default to always add parents around arrow function arguments: https://github.com/prettier/prettier/issues/6929