### PR TITLE
fix: do not error on imports in homey-app config

### DIFF
--- a/homey-app.js
+++ b/homey-app.js
@@ -13,6 +13,9 @@ module.exports = {
   },
 
   "rules": {
+    "node/no-missing-import": ["error", { "allowModules": ["homey"] }],
+    "node/no-unsupported-features/es-syntax": ["error", { "ignores": ["modules"] }],
+
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/no-floating-promises": ["error", { "ignoreVoid": false }],
     "@typescript-eslint/no-misused-promises": "error",

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = {
     "arrow-body-style": "off",
 
     "node/no-missing-require": ["error", { "allowModules": ["homey"] }],
-    
+
     "node/no-unpublished-require": ["error", { "allowModules": ["homey"]}],
 
     "no-underscore-dangle": "off",


### PR DESCRIPTION
requiring `"homey"` is allowed by the "base" config, however i'm allowing importing of `"homey"` in the homey-app config. If an app uses TypeScript it may use modules so we shouldn't error.