### PR TITLE
Updated deploy workflow to use node 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: NPM Publish
 
 # About this workflow:
 # It is triggered on push events to branches production and testing. Then it performs a checkout of the current repo
-# and sets up a node environment (v20). Following, it will run `npm ci` to build the package. Next, it will look at your
+# and sets up a node environment (v24). Following, it will run `npm ci` to build the package. Next, it will look at your
 # commit message, if it includes '#patch', '#minor', or '#major' it will bump the package version accordingly.
 # Finally, the `npm publish` command will be run, when on branch testing it will run `npm publish --tag beta` to publish
 # it under the beta flag on npm. Note: if no '#patch', '#minor', or '#major' flag is present in the latest commit
@@ -61,10 +61,10 @@ jobs:
           git config --local user.email "sysadmin+githubactions@athom.com"
           git config --local user.name "Homey Github Actions Bot"
       # Configures a Node.js environment.
-      - name: Set up node 20 environment
+      - name: Set up node 24 environment
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           # Needed for publishing to npm
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
There's a bug in npm v10.x that causes it to fail when resolving a conflict for an optional peerDependency. Node 24 uses npm 11 by default, which fixes this behaviour.