### PR TITLE
chore: tune new v4.0.0/eslint8 rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,25 @@ module.exports = {
 
     "no-shadow": "off",
     "max-len": ["warn", 200],
+
+    "no-import-assign": "warn",
+    "no-loss-of-precision": "warn",
+    "no-constructor-return": "warn",
+    "no-setter-return": "warn",
+    "no-promise-executor-return": "warn",
+    "no-useless-backreference": "warn",
+    "import/no-import-module-exports": "warn",
+
+    "default-case-last": "off",
+    "default-param-last": "off",
+    "function-call-argument-newline": "off",
+    "function-paren-newline": ["error", "consistent"],
+    "grouped-accessor-pairs": "off",
+    "no-restricted-exports": "off",
+    "prefer-exponentiation-operator": "off",
+    "prefer-regex-literals": "off",
+    "no-nonoctal-decimal-escape": "off",
+    "import/no-relative-packages": "off",
   },
   "overrides": [
     {


### PR DESCRIPTION
The airbnb-base/eslint8 upgrade in v4.0.0 turned on a set of new rules. Went through them individually and grouped by how they should behave:

Kept as error (likely to catch legit bugs):
- no-dupe-else-if
- no-unreachable-loop
- no-unsafe-optional-chaining

Downgraded to warn (useful, but these patterns may already exist in our repos, and we don't want this upgrade to trigger new hard errors):
- no-import-assign
- no-loss-of-precision
- no-constructor-return
- no-setter-return
- no-promise-executor-return
- no-useless-backreference
- import/no-import-module-exports

Turned off (stylistic, don't add much value, but can definitely cause new errors):
- default-case-last
- default-param-last
- function-call-argument-newline
- function-paren-newline (reverted option to "consistent")
- grouped-accessor-pairs
- no-restricted-exports
- prefer-exponentiation-operator
- prefer-regex-literals
- no-nonoctal-decimal-escape
- import/no-relative-packages